### PR TITLE
Update _latest_version to 0.982

### DIFF
--- a/pywavesurfer/ws.py
+++ b/pywavesurfer/ws.py
@@ -7,7 +7,7 @@ from packaging.version import parse as parse_version
 from packaging.specifiers import SpecifierSet
 
 # the latest version pywavesurfer was tested against
-_latest_version = 0.97
+_latest_version = 0.982
 _over_version_1 = SpecifierSet(">=1.0")
 
 # from pywavesurfer.ws import * will only import loadDataFile


### PR DESCRIPTION
I've been using PyWaveSurfer to load data generated from WaveSurfer v0.982 for over a year now, and have not run into any issues. Using pyton=3.9.11 & pip=22.3.